### PR TITLE
#2 feat : 자료구조에 따른 노드 배치 (마인드맵 그리기)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,12 +4,12 @@
     "es2021": true
   },
   "extends": [
-    "eslint:recommended",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
     "airbnb",
     "airbnb/hooks",
-    "airbnb-typescript"
+    "airbnb-typescript",
+    "prettier"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,8 +8,7 @@
     "plugin:@typescript-eslint/recommended",
     "airbnb",
     "airbnb/hooks",
-    "airbnb-typescript",
-    "prettier"
+    "airbnb-typescript"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,12 +4,12 @@
     "es2021": true
   },
   "extends": [
+    "eslint:recommended",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
     "airbnb",
     "airbnb/hooks",
-    "airbnb-typescript",
-    "prettier"
+    "airbnb-typescript"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
     "plugin:@typescript-eslint/recommended",
     "airbnb",
     "airbnb/hooks",
-    "airbnb-typescript"
+    "airbnb-typescript",
+    "prettier"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,8 @@
     "plugin:@typescript-eslint/recommended",
     "airbnb",
     "airbnb/hooks",
-    "airbnb-typescript"
+    "airbnb-typescript",
+    "prettier"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,11 @@
   },
   "plugins": ["react", "@typescript-eslint"],
   "rules": {
-    "react/react-in-jsx-scope": "off"
+    "import/prefer-default-export": "off",
+    "react/react-in-jsx-scope": "off",
+    "react/function-component-definition": [
+      2,
+      { "namedComponents": "arrow-function" }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,12 +11,15 @@
   "packageManager": "yarn@3.2.4",
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "recoil": "^0.7.7",
+    "styled-components": "^5.3.9"
   },
   "devDependencies": {
     "@types/eslint": "^8",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
+    "@types/styled-components": "^5",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "@vitejs/plugin-react": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint": "^8.35.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.0.0",
+    "eslint-config-prettier": "^8.7.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.32.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,15 @@
-import { useState } from 'react';
-import './App.css';
+import { RecoilRoot } from 'recoil';
+import Node from './components/organisms/Node';
+import { NodeDirection } from './constants/node';
 
-function App() {
-  const [count, setCount] = useState(0);
-
-  return <div className="App" />;
-}
+const App = () => (
+  <RecoilRoot>
+    <Node
+      nodeId={1}
+      direction={NodeDirection.right}
+      parentPosition={{ x: 0, y: 0 }}
+    />
+  </RecoilRoot>
+);
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,10 @@
 import { RecoilRoot } from 'recoil';
-import Node from './components/organisms/Node';
-import { NodeDirection } from './constants/node';
+import Root from './components/organisms/Root';
+import { RootVariant } from './constants/node';
 
 const App = () => (
   <RecoilRoot>
-    <Node
-      nodeId={1}
-      direction={NodeDirection.right}
-      parentPosition={{ x: 0, y: 0 }}
-    />
+    <Root rootVariant={RootVariant.BOTH_SIDE} />
   </RecoilRoot>
 );
 

--- a/src/components/organisms/LineContainer/index.tsx
+++ b/src/components/organisms/LineContainer/index.tsx
@@ -1,0 +1,24 @@
+import { useRecoilValue } from 'recoil';
+import lineState from 'src/recoil/lineState';
+import { NodeLine } from 'src/types/node';
+import * as s from './style';
+
+interface LineContainerProps {
+  width: number;
+  height: number;
+}
+
+const LineContainer = ({ width, height }: LineContainerProps) => {
+  const lineInfo = useRecoilValue(lineState);
+  const lines: NodeLine[] = Object.values(lineInfo);
+
+  return (
+    <s.Container width={width} height={height}>
+      {lines.map(({ x, y, parentX, parentY }) => (
+        <s.Line key={`${x}${y}`} x1={parentX} y1={parentY} x2={x} y2={y} />
+      ))}
+    </s.Container>
+  );
+};
+
+export default LineContainer;

--- a/src/components/organisms/LineContainer/style.ts
+++ b/src/components/organisms/LineContainer/style.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const Container = styled.svg<{ width: number; height: number }>`
+  width: ${({ width }) => `${width}px`};
+  height: ${({ height }) => `${height}px`};
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+`;
+
+export const Line = styled.line`
+  stroke: black;
+`;

--- a/src/components/organisms/Node/index.tsx
+++ b/src/components/organisms/Node/index.tsx
@@ -1,17 +1,14 @@
 import { useRecoilValue } from 'recoil';
 import nodeState from 'src/recoil/nodeState';
 import useElementPosition from 'src/hooks/useElementPosition';
-import { NodeId } from 'src/types/node';
+import { NodeId, NodePosition } from 'src/types/node';
 import { NodeDirection } from 'src/constants/node';
 import * as s from './style';
 
 interface NodeProps {
   nodeId: NodeId;
   direction: NodeDirection;
-  parentPosition: {
-    x: number;
-    y: number;
-  };
+  parentPosition: NodePosition;
 }
 
 const Node = ({ nodeId, direction, parentPosition }: NodeProps) => {
@@ -28,7 +25,7 @@ const Node = ({ nodeId, direction, parentPosition }: NodeProps) => {
   ));
 
   return (
-    <s.Wrapper>
+    <s.Wrapper direction={direction}>
       {direction === NodeDirection.top && <s.Row>{childrenNodes}</s.Row>}
       {direction === NodeDirection.left && <s.Column>{childrenNodes}</s.Column>}
       <s.Node ref={ref}>{nodeId}</s.Node>

--- a/src/components/organisms/Node/index.tsx
+++ b/src/components/organisms/Node/index.tsx
@@ -19,6 +19,9 @@ const Node = ({ nodeId, direction, parentPosition }: NodeProps) => {
   const { ref, position } = useElementPosition<HTMLDivElement>();
 
   useEffect(() => {
+    if (!position.x && !position.y) {
+      return;
+    }
     setLine((state) => {
       const newState = { ...state };
       newState[nodeId] = {

--- a/src/components/organisms/Node/index.tsx
+++ b/src/components/organisms/Node/index.tsx
@@ -1,0 +1,43 @@
+import { useRecoilValue } from 'recoil';
+import nodeState from 'src/recoil/nodeState';
+import useElementPosition from 'src/hooks/useElementPosition';
+import { NodeId } from 'src/types/node';
+import { NodeDirection } from 'src/constants/node';
+import * as s from './style';
+
+interface NodeProps {
+  nodeId: NodeId;
+  direction: NodeDirection;
+  parentPosition: {
+    x: number;
+    y: number;
+  };
+}
+
+const Node = ({ nodeId, direction, parentPosition }: NodeProps) => {
+  const { children } = useRecoilValue(nodeState)[nodeId];
+  const { ref, position } = useElementPosition<HTMLDivElement>();
+
+  const childrenNodes = children.map((id) => (
+    <Node
+      key={id}
+      nodeId={id}
+      direction={direction}
+      parentPosition={position}
+    />
+  ));
+
+  return (
+    <s.Wrapper>
+      {direction === NodeDirection.top && <s.Row>{childrenNodes}</s.Row>}
+      {direction === NodeDirection.left && <s.Column>{childrenNodes}</s.Column>}
+      <s.Node ref={ref}>{nodeId}</s.Node>
+      {direction === NodeDirection.bottom && <s.Row>{childrenNodes}</s.Row>}
+      {direction === NodeDirection.right && (
+        <s.Column>{childrenNodes}</s.Column>
+      )}
+    </s.Wrapper>
+  );
+};
+
+export default Node;

--- a/src/components/organisms/Node/index.tsx
+++ b/src/components/organisms/Node/index.tsx
@@ -1,5 +1,7 @@
-import { useRecoilValue } from 'recoil';
+import { useEffect } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import nodeState from 'src/recoil/nodeState';
+import lineState from 'src/recoil/lineState';
 import useElementPosition from 'src/hooks/useElementPosition';
 import { NodeId, NodePosition } from 'src/types/node';
 import { NodeDirection } from 'src/constants/node';
@@ -13,7 +15,20 @@ interface NodeProps {
 
 const Node = ({ nodeId, direction, parentPosition }: NodeProps) => {
   const { children } = useRecoilValue(nodeState)[nodeId];
+  const setLine = useSetRecoilState(lineState);
   const { ref, position } = useElementPosition<HTMLDivElement>();
+
+  useEffect(() => {
+    setLine((state) => {
+      const newState = { ...state };
+      newState[nodeId] = {
+        ...position,
+        parentX: parentPosition.x,
+        parentY: parentPosition.y,
+      };
+      return newState;
+    });
+  }, [nodeId, parentPosition, position, setLine]);
 
   const childrenNodes = children.map((id) => (
     <Node

--- a/src/components/organisms/Node/style.ts
+++ b/src/components/organisms/Node/style.ts
@@ -18,7 +18,7 @@ export const Column = styled.div`
 export const Row = styled.div``;
 
 export const Node = styled.div`
-  margin: 10px;
+  margin: 20px;
   padding: 10px;
   background: aquamarine;
 `;

--- a/src/components/organisms/Node/style.ts
+++ b/src/components/organisms/Node/style.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Row = styled.div``;
+
+export const Node = styled.div`
+  margin: 10px;
+  padding: 10px;
+  background: aquamarine;
+`;

--- a/src/components/organisms/Node/style.ts
+++ b/src/components/organisms/Node/style.ts
@@ -1,8 +1,13 @@
 import styled from 'styled-components';
+import { NodeDirection } from 'src/constants/node';
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.div<{ direction: NodeDirection }>`
   display: flex;
   align-items: center;
+  justify-content: ${({ direction }) =>
+    [NodeDirection.top, NodeDirection.left].includes(direction)
+      ? 'flex-end'
+      : 'flex-start'};
 `;
 
 export const Column = styled.div`

--- a/src/components/organisms/Root/BothSideRoot.tsx
+++ b/src/components/organisms/Root/BothSideRoot.tsx
@@ -1,0 +1,47 @@
+import { ReactNode } from 'react';
+import { NodeChildren, NodePosition } from 'src/types/node';
+import { NodeDirection } from 'src/constants/node';
+import Node from 'src/components/organisms/Node';
+import * as s from './style';
+
+interface BothSideRootProps {
+  rootNode: ReactNode;
+  children: NodeChildren;
+  position: NodePosition;
+}
+
+const BothSideRoot = ({ rootNode, children, position }: BothSideRootProps) => (
+  <>
+    <s.Column>
+      {children.map(
+        (id, index) =>
+          !!(index % 2) && (
+            <Node
+              key={id}
+              nodeId={id}
+              parentPosition={position}
+              direction={NodeDirection.left}
+            />
+          ),
+      )}
+    </s.Column>
+
+    {rootNode}
+
+    <s.Column>
+      {children.map(
+        (id, index) =>
+          !(index % 2) && (
+            <Node
+              key={id}
+              nodeId={id}
+              parentPosition={position}
+              direction={NodeDirection.right}
+            />
+          ),
+      )}
+    </s.Column>
+  </>
+);
+
+export default BothSideRoot;

--- a/src/components/organisms/Root/BothSideRoot.tsx
+++ b/src/components/organisms/Root/BothSideRoot.tsx
@@ -6,14 +6,18 @@ import * as s from './style';
 
 interface BothSideRootProps {
   rootNode: ReactNode;
-  children: NodeChildren;
+  childrenNodes: NodeChildren;
   position: NodePosition;
 }
 
-const BothSideRoot = ({ rootNode, children, position }: BothSideRootProps) => (
+const BothSideRoot = ({
+  rootNode,
+  childrenNodes,
+  position,
+}: BothSideRootProps) => (
   <>
     <s.Column>
-      {children.map(
+      {childrenNodes.map(
         (id, index) =>
           !!(index % 2) && (
             <Node
@@ -29,7 +33,7 @@ const BothSideRoot = ({ rootNode, children, position }: BothSideRootProps) => (
     {rootNode}
 
     <s.Column>
-      {children.map(
+      {childrenNodes.map(
         (id, index) =>
           !(index % 2) && (
             <Node

--- a/src/components/organisms/Root/index.tsx
+++ b/src/components/organisms/Root/index.tsx
@@ -1,0 +1,35 @@
+import { useRecoilValue } from 'recoil';
+import useElementPosistion from 'src/hooks/useElementPosition';
+import nodeState from 'src/recoil/nodeState';
+import { RootVariant } from 'src/constants/node';
+import BothSideRoot from './BothSideRoot';
+import * as s from './style';
+
+const ROOT_ID = 0;
+
+interface RootProps {
+  rootVariant: RootVariant;
+}
+
+const Root = ({ rootVariant }: RootProps) => {
+  const { children } = useRecoilValue(nodeState)[ROOT_ID];
+  const { ref, position } = useElementPosistion<HTMLDivElement>();
+
+  if (rootVariant === RootVariant.OTHER) {
+    return null;
+  }
+
+  const rootNode = <s.Node ref={ref}>ROOT</s.Node>;
+
+  return (
+    <s.Wrapper>
+      <BothSideRoot
+        rootNode={rootNode}
+        children={children}
+        position={position}
+      />
+    </s.Wrapper>
+  );
+};
+
+export default Root;

--- a/src/components/organisms/Root/index.tsx
+++ b/src/components/organisms/Root/index.tsx
@@ -4,6 +4,7 @@ import nodeState from 'src/recoil/nodeState';
 import { RootVariant } from 'src/constants/node';
 import BothSideRoot from './BothSideRoot';
 import * as s from './style';
+import LineContainer from '../LineContainer';
 
 const ROOT_ID = 0;
 
@@ -22,13 +23,16 @@ const Root = ({ rootVariant }: RootProps) => {
   const rootNode = <s.Node ref={ref}>ROOT</s.Node>;
 
   return (
-    <s.Wrapper>
-      <BothSideRoot
-        rootNode={rootNode}
-        children={children}
-        position={position}
-      />
-    </s.Wrapper>
+    <s.Background width={2000} height={1000}>
+      <s.Wrapper>
+        <BothSideRoot
+          rootNode={rootNode}
+          childrenNodes={children}
+          position={position}
+        />
+      </s.Wrapper>
+      <LineContainer width={2000} height={1000} />
+    </s.Background>
   );
 };
 

--- a/src/components/organisms/Root/index.tsx
+++ b/src/components/organisms/Root/index.tsx
@@ -1,12 +1,15 @@
+import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 import useElementPosistion from 'src/hooks/useElementPosition';
 import nodeState from 'src/recoil/nodeState';
 import { RootVariant } from 'src/constants/node';
+import LineContainer from 'src/components/organisms/LineContainer';
 import BothSideRoot from './BothSideRoot';
 import * as s from './style';
-import LineContainer from '../LineContainer';
 
 const ROOT_ID = 0;
+const WIDTH = 2000;
+const HEIGHT = 1000;
 
 interface RootProps {
   rootVariant: RootVariant;
@@ -16,6 +19,10 @@ const Root = ({ rootVariant }: RootProps) => {
   const { children } = useRecoilValue(nodeState)[ROOT_ID];
   const { ref, position } = useElementPosistion<HTMLDivElement>();
 
+  useEffect(() => {
+    window.scrollTo(WIDTH / 7, HEIGHT / 7);
+  }, []);
+
   if (rootVariant === RootVariant.OTHER) {
     return null;
   }
@@ -23,7 +30,7 @@ const Root = ({ rootVariant }: RootProps) => {
   const rootNode = <s.Node ref={ref}>ROOT</s.Node>;
 
   return (
-    <s.Background width={2000} height={1000}>
+    <s.Background width={WIDTH} height={HEIGHT}>
       <s.Wrapper>
         <BothSideRoot
           rootNode={rootNode}
@@ -31,7 +38,7 @@ const Root = ({ rootVariant }: RootProps) => {
           position={position}
         />
       </s.Wrapper>
-      <LineContainer width={2000} height={1000} />
+      <LineContainer width={WIDTH} height={HEIGHT} />
     </s.Background>
   );
 };

--- a/src/components/organisms/Root/style.ts
+++ b/src/components/organisms/Root/style.ts
@@ -1,6 +1,12 @@
 import styled from 'styled-components';
 
+export const Background = styled.div<{ width: number; height: number }>`
+  width: ${({ width }) => `${width}px`};
+  height: ${({ height }) => `${height}px`};
+`;
+
 export const Wrapper = styled.div`
+  z-index: 1;
   width: 100%;
   height: 100%;
   display: flex;
@@ -8,7 +14,6 @@ export const Wrapper = styled.div`
   align-items: center;
   position: relative;
   gap: 30px;
-  zindex: 1;
 `;
 
 export const Column = styled.div`

--- a/src/components/organisms/Root/style.ts
+++ b/src/components/organisms/Root/style.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  gap: 30px;
+  zindex: 1;
+`;
+
+export const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Node = styled.div`
+  padding: 10px;
+  background: chartreuse;
+`;

--- a/src/constants/node.ts
+++ b/src/constants/node.ts
@@ -1,0 +1,6 @@
+export enum NodeDirection {
+  top = 1,
+  right = 2,
+  bottom = 3,
+  left = 4,
+}

--- a/src/constants/node.ts
+++ b/src/constants/node.ts
@@ -4,3 +4,8 @@ export enum NodeDirection {
   bottom = 3,
   left = 4,
 }
+
+export enum RootVariant {
+  BOTH_SIDE = 'bothSide',
+  OTHER = 'other',
+}

--- a/src/hooks/useElementPosition.ts
+++ b/src/hooks/useElementPosition.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef, useState } from 'react';
+
+const useElementPosistion = () => {
+  const ref = useRef<HTMLElement>(null);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const rect = ref.current?.getBoundingClientRect();
+    if (rect) {
+      setPosition({
+        x: window.scrollX + rect.x + rect.width / 2,
+        y: window.scrollY + rect.y + rect.height / 2,
+      });
+    }
+  }, [ref]);
+
+  return { ref, position };
+};
+
+export default useElementPosistion;

--- a/src/hooks/useElementPosition.ts
+++ b/src/hooks/useElementPosition.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-const useElementPosistion = () => {
+const useElementPosition = () => {
   const ref = useRef<HTMLElement>(null);
   const [position, setPosition] = useState({ x: 0, y: 0 });
 
@@ -17,4 +17,4 @@ const useElementPosistion = () => {
   return { ref, position };
 };
 
-export default useElementPosistion;
+export default useElementPosition;

--- a/src/hooks/useElementPosition.ts
+++ b/src/hooks/useElementPosition.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
-const useElementPosition = () => {
-  const ref = useRef<HTMLElement>(null);
+const useElementPosition = <T extends HTMLElement>() => {
+  const ref = useRef<T>(null);
   const [position, setPosition] = useState({ x: 0, y: 0 });
 
   useEffect(() => {

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -1,0 +1,51 @@
+import { Node } from './types/node';
+
+const nodeInfo: Node = {
+  0: {
+    children: [1, 2, 3, 4],
+  },
+  1: {
+    children: [5, 6, 7],
+  },
+  2: {
+    children: [8, 9],
+  },
+  3: {
+    children: [],
+  },
+  4: {
+    children: [10],
+  },
+  5: {
+    children: [],
+  },
+  6: {
+    children: [],
+  },
+  7: {
+    children: [11],
+  },
+  8: {
+    children: [],
+  },
+  9: {
+    children: [12, 13, 14],
+  },
+  10: {
+    children: [],
+  },
+  11: {
+    children: [],
+  },
+  12: {
+    children: [],
+  },
+  13: {
+    children: [],
+  },
+  14: {
+    children: [],
+  },
+};
+
+export default nodeInfo;

--- a/src/recoil/lineState.ts
+++ b/src/recoil/lineState.ts
@@ -1,0 +1,18 @@
+import { atom } from 'recoil';
+import { NodeId } from 'src/types/node';
+
+interface LineState {
+  [key: NodeId]: {
+    x: number;
+    y: number;
+    parentX: number;
+    parentY: number;
+  };
+}
+
+const lineState = atom<LineState>({
+  key: 'lineState',
+  default: {},
+});
+
+export default lineState;

--- a/src/recoil/lineState.ts
+++ b/src/recoil/lineState.ts
@@ -1,13 +1,8 @@
 import { atom } from 'recoil';
-import { NodeId } from 'src/types/node';
+import { NodeId, NodeLine } from 'src/types/node';
 
 interface LineState {
-  [key: NodeId]: {
-    x: number;
-    y: number;
-    parentX: number;
-    parentY: number;
-  };
+  [key: NodeId]: NodeLine;
 }
 
 const lineState = atom<LineState>({

--- a/src/recoil/nodeState.ts
+++ b/src/recoil/nodeState.ts
@@ -1,0 +1,9 @@
+import { atom } from 'recoil';
+import nodeInfo from '../mock';
+
+const nodeState = atom({
+  key: 'nodeState',
+  default: nodeInfo,
+});
+
+export default nodeState;

--- a/src/recoil/nodeState.ts
+++ b/src/recoil/nodeState.ts
@@ -1,7 +1,8 @@
 import { atom } from 'recoil';
+import { Node } from 'src/types/node';
 import nodeInfo from '../mock';
 
-const nodeState = atom({
+const nodeState = atom<Node>({
   key: 'nodeState',
   default: nodeInfo,
 });

--- a/src/types/node.d.ts
+++ b/src/types/node.d.ts
@@ -1,5 +1,11 @@
-type NodeId = number;
+export type NodeId = number;
+export type NodeChildren = NodeId[];
 
 export interface Node {
-  [key: NodeId]: { children: NodeId[] };
+  [key: NodeId]: { children: NodeChildren };
+}
+
+export interface NodePosition {
+  x: number;
+  y: number;
 }

--- a/src/types/node.d.ts
+++ b/src/types/node.d.ts
@@ -3,10 +3,3 @@ type NodeId = number;
 export interface Node {
   [key: NodeId]: { children: NodeId[] };
 }
-
-export enum NodeDirection {
-  top = 1,
-  right = 2,
-  bottom = 3,
-  left = 4,
-}

--- a/src/types/node.d.ts
+++ b/src/types/node.d.ts
@@ -1,6 +1,7 @@
+type NodeId = number;
+
 export interface Node {
-  id: number;
-  children: Node[];
+  [key: NodeId]: { children: NodeId[] };
 }
 
 export enum NodeDirection {

--- a/src/types/node.d.ts
+++ b/src/types/node.d.ts
@@ -9,3 +9,8 @@ export interface NodePosition {
   x: number;
   y: number;
 }
+
+export interface NodeLine extends NodePosition {
+  parentX: number;
+  parentY: number;
+}

--- a/src/types/node.d.ts
+++ b/src/types/node.d.ts
@@ -1,0 +1,11 @@
+export interface Node {
+  id: number;
+  children: Node[];
+}
+
+export enum NodeDirection {
+  top = 1,
+  right = 2,
+  bottom = 3,
+  left = 4,
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": "./"
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1782,6 +1782,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-config-prettier@npm:^8.7.0":
+  version: 8.7.0
+  resolution: "eslint-config-prettier@npm:8.7.0"
+  peerDependencies:
+    eslint: ">=7.0.0"
+  bin:
+    eslint-config-prettier: bin/cli.js
+  checksum: b05bc7f2296ce3e0925c14147849706544870e0382d38af2352d709a6cf8521bdaff2bd8e5021f1780e570775a8ffa1d2bac28b8065d90d43a3f1f98fd26ce52
+  languageName: node
+  linkType: hard
+
 "eslint-import-resolver-node@npm:^0.3.7":
   version: 0.3.7
   resolution: "eslint-import-resolver-node@npm:0.3.7"
@@ -2365,6 +2376,7 @@ __metadata:
     eslint: ^8.35.0
     eslint-config-airbnb: ^19.0.4
     eslint-config-airbnb-typescript: ^17.0.0
+    eslint-config-prettier: ^8.7.0
     eslint-plugin-import: ^2.27.5
     eslint-plugin-jsx-a11y: ^6.7.1
     eslint-plugin-react: ^7.32.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,6 +66,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.21.3":
+  version: 7.21.3
+  resolution: "@babel/generator@npm:7.21.3"
+  dependencies:
+    "@babel/types": ^7.21.3
+    "@jridgewell/gen-mapping": ^0.3.2
+    "@jridgewell/trace-mapping": ^0.3.17
+    jsesc: ^2.5.1
+  checksum: be6bb5a32a0273260b91210d4137b7b5da148a2db8dd324654275cb0af865ae59de5e1536e93ac83423b2586415059e1c24cf94293026755cf995757238da749
+  languageName: node
+  linkType: hard
+
+"@babel/helper-annotate-as-pure@npm:^7.16.0":
+  version: 7.18.6
+  resolution: "@babel/helper-annotate-as-pure@npm:7.18.6"
+  dependencies:
+    "@babel/types": ^7.18.6
+  checksum: 88ccd15ced475ef2243fdd3b2916a29ea54c5db3cd0cfabf9d1d29ff6e63b7f7cd1c27264137d7a40ac2e978b9b9a542c332e78f40eb72abe737a7400788fc1b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-compilation-targets@npm:^7.20.7":
   version: 7.20.7
   resolution: "@babel/helper-compilation-targets@npm:7.20.7"
@@ -107,7 +128,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.18.6":
+"@babel/helper-module-imports@npm:^7.0.0, @babel/helper-module-imports@npm:^7.16.0, @babel/helper-module-imports@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-module-imports@npm:7.18.6"
   dependencies:
@@ -209,6 +230,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:^7.21.3":
+  version: 7.21.3
+  resolution: "@babel/parser@npm:7.21.3"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: a71e6456a1260c2a943736b56cc0acdf5f2a53c6c79e545f56618967e51f9b710d1d3359264e7c979313a7153741b1d95ad8860834cc2ab4ce4f428b13cc07be
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-react-jsx-self@npm:^7.18.6":
   version: 7.21.0
   resolution: "@babel/plugin-transform-react-jsx-self@npm:7.21.0"
@@ -269,6 +299,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.4.5":
+  version: 7.21.3
+  resolution: "@babel/traverse@npm:7.21.3"
+  dependencies:
+    "@babel/code-frame": ^7.18.6
+    "@babel/generator": ^7.21.3
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-function-name": ^7.21.0
+    "@babel/helper-hoist-variables": ^7.18.6
+    "@babel/helper-split-export-declaration": ^7.18.6
+    "@babel/parser": ^7.21.3
+    "@babel/types": ^7.21.3
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: 0af5bcd47a2fc501592b90ac1feae9d449afb9ab0772a4f6e68230f4cd3a475795d538c1de3f880fe3414b6c2820bac84d02c6549eea796f39d74a603717447b
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.18.6, @babel/types@npm:^7.20.2, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.0, @babel/types@npm:^7.21.2, @babel/types@npm:^7.8.3":
   version: 7.21.2
   resolution: "@babel/types@npm:7.21.2"
@@ -277,6 +325,47 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.19.1
     to-fast-properties: ^2.0.0
   checksum: a45a52acde139e575502c6de42c994bdbe262bafcb92ae9381fb54cdf1a3672149086843fda655c7683ce9806e998fd002bbe878fa44984498d0fdc7935ce7ff
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.21.3":
+  version: 7.21.3
+  resolution: "@babel/types@npm:7.21.3"
+  dependencies:
+    "@babel/helper-string-parser": ^7.19.4
+    "@babel/helper-validator-identifier": ^7.19.1
+    to-fast-properties: ^2.0.0
+  checksum: b750274718ba9cefd0b81836c464009bb6ba339fccce51b9baff497a0a2d96c044c61dc90cf203cec0adc770454b53a9681c3f7716883c802b85ab84c365ba35
+  languageName: node
+  linkType: hard
+
+"@emotion/is-prop-valid@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "@emotion/is-prop-valid@npm:1.2.0"
+  dependencies:
+    "@emotion/memoize": ^0.8.0
+  checksum: cc7a19850a4c5b24f1514665289442c8c641709e6f7711067ad550e05df331da0692a16148e85eda6f47e31b3261b64d74c5e25194d053223be16231f969d633
+  languageName: node
+  linkType: hard
+
+"@emotion/memoize@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@emotion/memoize@npm:0.8.0"
+  checksum: c87bb110b829edd8e1c13b90a6bc37cebc39af29c7599a1e66a48e06f9bec43e8e53495ba86278cc52e7589549492c8dfdc81d19f4fdec0cee6ba13d2ad2c928
+  languageName: node
+  linkType: hard
+
+"@emotion/stylis@npm:^0.8.4":
+  version: 0.8.5
+  resolution: "@emotion/stylis@npm:0.8.5"
+  checksum: 67ff5958449b2374b329fb96e83cb9025775ffe1e79153b499537c6c8b2eb64b77f32d7b5d004d646973662356ceb646afd9269001b97c54439fceea3203ce65
+  languageName: node
+  linkType: hard
+
+"@emotion/unitless@npm:^0.7.4":
+  version: 0.7.5
+  resolution: "@emotion/unitless@npm:0.7.5"
+  checksum: f976e5345b53fae9414a7b2e7a949aa6b52f8bdbcc84458b1ddc0729e77ba1d1dfdff9960e0da60183877873d3a631fa24d9695dd714ed94bcd3ba5196586a6b
   languageName: node
   linkType: hard
 
@@ -613,6 +702,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/hoist-non-react-statics@npm:*":
+  version: 3.3.1
+  resolution: "@types/hoist-non-react-statics@npm:3.3.1"
+  dependencies:
+    "@types/react": "*"
+    hoist-non-react-statics: ^3.3.0
+  checksum: 2c0778570d9a01d05afabc781b32163f28409bb98f7245c38d5eaf082416fdb73034003f5825eb5e21313044e8d2d9e1f3fe2831e345d3d1b1d20bcd12270719
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:*, @types/json-schema@npm:^7.0.9":
   version: 7.0.11
   resolution: "@types/json-schema@npm:7.0.11"
@@ -665,6 +764,17 @@ __metadata:
   version: 7.3.13
   resolution: "@types/semver@npm:7.3.13"
   checksum: 00c0724d54757c2f4bc60b5032fe91cda6410e48689633d5f35ece8a0a66445e3e57fa1d6e07eb780f792e82ac542948ec4d0b76eb3484297b79bd18b8cf1cb0
+  languageName: node
+  linkType: hard
+
+"@types/styled-components@npm:^5":
+  version: 5.1.26
+  resolution: "@types/styled-components@npm:5.1.26"
+  dependencies:
+    "@types/hoist-non-react-statics": "*"
+    "@types/react": "*"
+    csstype: ^3.0.2
+  checksum: 84f53b3101739b20d1731554fb7735bc2f3f5d050a8b392e9845403c8c8bbd729737d033978649f9195a97b557875b010d46e35a4538564a2d0dbcce661dbf76
   languageName: node
   linkType: hard
 
@@ -1016,6 +1126,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-styled-components@npm:>= 1.12.0":
+  version: 2.0.7
+  resolution: "babel-plugin-styled-components@npm:2.0.7"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.16.0
+    "@babel/helper-module-imports": ^7.16.0
+    babel-plugin-syntax-jsx: ^6.18.0
+    lodash: ^4.17.11
+    picomatch: ^2.3.0
+  peerDependencies:
+    styled-components: ">= 2"
+  checksum: 80b06b10db02d749432a0ac43a5feedd686f6b648628d7433a39b1844260b2b7c72431f6e705c82636ee025fcfd4f6c32fc05677e44033b8a39ddcd4488b3147
+  languageName: node
+  linkType: hard
+
+"babel-plugin-syntax-jsx@npm:^6.18.0":
+  version: 6.18.0
+  resolution: "babel-plugin-syntax-jsx@npm:6.18.0"
+  checksum: 0c7ce5b81d6cfc01a7dd7a76a9a8f090ee02ba5c890310f51217ef1a7e6163fb7848994bbc14fd560117892e82240df9c7157ad0764da67ca5f2afafb73a7d27
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -1105,6 +1237,13 @@ __metadata:
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
   checksum: 072d17b6abb459c2ba96598918b55868af677154bec7e73d222ef95a8fdb9bbf7dae96a8421085cdad8cd190d86653b5b6dc55a4484f2e5b2e27d5e0c3fc15b3
+  languageName: node
+  linkType: hard
+
+"camelize@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "camelize@npm:1.0.1"
+  checksum: 91d8611d09af725e422a23993890d22b2b72b4cabf7239651856950c76b4bf53fe0d0da7c5e4db05180e898e4e647220e78c9fbc976113bd96d603d1fcbfcb99
   languageName: node
   linkType: hard
 
@@ -1227,6 +1366,24 @@ __metadata:
     shebang-command: ^2.0.0
     which: ^2.0.1
   checksum: 671cc7c7288c3a8406f3c69a3ae2fc85555c04169e9d611def9a675635472614f1c0ed0ef80955d5b6d4e724f6ced67f0ad1bb006c2ea643488fcfef994d7f52
+  languageName: node
+  linkType: hard
+
+"css-color-keywords@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "css-color-keywords@npm:1.0.0"
+  checksum: 8f125e3ad477bd03c77b533044bd9e8a6f7c0da52d49bbc0bbe38327b3829d6ba04d368ca49dd9ff3b667d2fc8f1698d891c198bbf8feade1a5501bf5a296408
+  languageName: node
+  linkType: hard
+
+"css-to-react-native@npm:^3.0.0":
+  version: 3.2.0
+  resolution: "css-to-react-native@npm:3.2.0"
+  dependencies:
+    camelize: ^1.0.0
+    css-color-keywords: ^1.0.0
+    postcss-value-parser: ^4.0.2
+  checksum: 263be65e805aef02c3f20c064665c998a8c35293e1505dbe6e3054fb186b01a9897ac6cf121f9840e5a9dfe3fb3994f6fcd0af84a865f1df78ba5bf89e77adce
   languageName: node
   linkType: hard
 
@@ -2201,6 +2358,7 @@ __metadata:
     "@types/eslint": ^8
     "@types/react": ^18.0.28
     "@types/react-dom": ^18.0.11
+    "@types/styled-components": ^5
     "@typescript-eslint/eslint-plugin": ^5.0.0
     "@typescript-eslint/parser": ^5.0.0
     "@vitejs/plugin-react": ^3.1.0
@@ -2213,11 +2371,20 @@ __metadata:
     eslint-plugin-react-hooks: ^4.6.0
     react: ^18.2.0
     react-dom: ^18.2.0
+    recoil: ^0.7.7
+    styled-components: ^5.3.9
     typescript: ^4.9.5
     vite: ^4.1.4
     vite-tsconfig-paths: ^4.0.5
   languageName: unknown
   linkType: soft
+
+"hamt_plus@npm:1.0.2":
+  version: 1.0.2
+  resolution: "hamt_plus@npm:1.0.2"
+  checksum: af26ea32db03009019cc83dfa9411521a2fa16079443de1a502c9be46d8b3c975acda8ed93fc5750ef08d3186d35901e2d8cfe717dd54bea67b358601fa74e4c
+  languageName: node
+  linkType: hard
 
 "has-bigints@npm:^1.0.1, has-bigints@npm:^1.0.2":
   version: 1.0.2
@@ -2285,6 +2452,15 @@ __metadata:
   dependencies:
     function-bind: ^1.1.1
   checksum: b9ad53d53be4af90ce5d1c38331e712522417d017d5ef1ebd0507e07c2fbad8686fffb8e12ddecd4c39ca9b9b47431afbb975b8abf7f3c3b82c98e9aad052792
+  languageName: node
+  linkType: hard
+
+"hoist-non-react-statics@npm:^3.0.0, hoist-non-react-statics@npm:^3.3.0":
+  version: 3.3.2
+  resolution: "hoist-non-react-statics@npm:3.3.2"
+  dependencies:
+    react-is: ^16.7.0
+  checksum: b1538270429b13901ee586aa44f4cc3ecd8831c061d06cb8322e50ea17b3f5ce4d0e2e66394761e6c8e152cd8c34fb3b4b690116c6ce2bd45b18c746516cb9e8
   languageName: node
   linkType: hard
 
@@ -2753,6 +2929,13 @@ __metadata:
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
+  languageName: node
+  linkType: hard
+
+"lodash@npm:^4.17.11":
+  version: 4.17.21
+  resolution: "lodash@npm:4.17.21"
+  checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
   languageName: node
   linkType: hard
 
@@ -3234,10 +3417,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.3.1":
+"picomatch@npm:^2.3.0, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 050c865ce81119c4822c45d3c84f1ced46f93a0126febae20737bd05ca20589c564d6e9226977df859ed5e03dc73f02584a2b0faad36e896936238238b0446cf
+  languageName: node
+  linkType: hard
+
+"postcss-value-parser@npm:^4.0.2":
+  version: 4.2.0
+  resolution: "postcss-value-parser@npm:4.2.0"
+  checksum: 819ffab0c9d51cf0acbabf8996dffbfafbafa57afc0e4c98db88b67f2094cb44488758f06e5da95d7036f19556a4a732525e84289a425f4f6fd8e412a9d7442f
   languageName: node
   linkType: hard
 
@@ -3313,7 +3503,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1":
+"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
@@ -3344,6 +3534,22 @@ __metadata:
     string_decoder: ^1.1.1
     util-deprecate: ^1.0.1
   checksum: b7ab0508dba3c37277b9e43c0a970ea27635375698859a687f558c3c9393154b6c4f39c3aa5689641de183fffa26771bc1a45878ddde0236ad18fc8fdfde50ea
+  languageName: node
+  linkType: hard
+
+"recoil@npm:^0.7.7":
+  version: 0.7.7
+  resolution: "recoil@npm:0.7.7"
+  dependencies:
+    hamt_plus: 1.0.2
+  peerDependencies:
+    react: ">=16.13.1"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: 65edecbcb8d2cde89bfd61ec679c200483472a6cd343c33e4e9142b6ce524fb17d1fecc2bfd8c392926aaa8178c81457f165b32abce2a9662f51f98822c0a9cc
   languageName: node
   linkType: hard
 
@@ -3540,6 +3746,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"shallowequal@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "shallowequal@npm:1.1.0"
+  checksum: f4c1de0837f106d2dbbfd5d0720a5d059d1c66b42b580965c8f06bb1db684be8783538b684092648c981294bf817869f743a066538771dbecb293df78f765e00
+  languageName: node
+  linkType: hard
+
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -3715,7 +3928,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^5.3.0":
+"styled-components@npm:^5.3.9":
+  version: 5.3.9
+  resolution: "styled-components@npm:5.3.9"
+  dependencies:
+    "@babel/helper-module-imports": ^7.0.0
+    "@babel/traverse": ^7.4.5
+    "@emotion/is-prop-valid": ^1.1.0
+    "@emotion/stylis": ^0.8.4
+    "@emotion/unitless": ^0.7.4
+    babel-plugin-styled-components: ">= 1.12.0"
+    css-to-react-native: ^3.0.0
+    hoist-non-react-statics: ^3.0.0
+    shallowequal: ^1.1.0
+    supports-color: ^5.5.0
+  peerDependencies:
+    react: ">= 16.8.0"
+    react-dom: ">= 16.8.0"
+    react-is: ">= 16.8.0"
+  checksum: 404311cc7028259218674d3f9f39bdda2342fc02f2ebbba8f057ef560b2ad205c5bd63b82deed4d0bf217ac7eb960d0e1127510b0b606e32cbd5a48c10373ce8
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^5.3.0, supports-color@npm:^5.5.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
   dependencies:


### PR DESCRIPTION
### 관련 이슈
> 현재 아래와 같이 전체 마인드맵 사이즈를 `WIDTH`, `HEIGHT`로 상수화하여 사용하고 있다.
> 마인드맵 사이즈를 동적으로 정의하기 위해 고민해봐야 할 것 같다.

```jsx
const WIDTH = 2000;
const HEIGHT = 1000;

...

const Root = ({ rootVariant }: RootProps) => {

  ...

  return (
    <s.Background width={WIDTH} height={HEIGHT}>
      <s.Wrapper>
        <BothSideRoot
          rootNode={rootNode}
          childrenNodes={children}
          position={position}
        />
      </s.Wrapper>
      <LineContainer width={WIDTH} height={HEIGHT} />
    </s.Background>
  );
}
```

### 작업 사항
- 마인드맵 Mock Data 생성
- 노드 타입 정의
- 루트 노드 컴포넌트 구현
- 자식 노드 컴포넌트 구현
- 컴포넌트 위치 반환 Hook 구현
- Recoil을 이용한 라인(노드 사이를 잇는) 상태 관리
- 라인 컨테이너 컴포넌트 구현

### 작업 요약
> 마인드맵에 대한 Mock 데이터를 생성하고, 해당 데이터 자료구조에 따라 마인드맵을 그리는 동작을 구현했다.

### 첨부
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/33220404/225840347-6accb46c-82f2-4bae-9905-285e15403bc2.png">